### PR TITLE
Avoid memory leaks in autoack mode

### DIFF
--- a/lib/set-consumer.js
+++ b/lib/set-consumer.js
@@ -66,8 +66,6 @@ function execAction(parsedMsg, rabQ, ch) {
     rabQ.unackedMessages[unackedMessageId] = parsedMsg;
   }
 
-  rabQ.unackedMessages[unackedMessageId] = parsedMsg;
-
   const msgSubscribers = rabQ.subscribers.filter(subscriber => subscriber.patternMatch.test(parsedMsg.rk));
 
   rabQ.emit('log', {


### PR DESCRIPTION
When it autoack mode each message was permanently stored in an array, causing memory leaks.