### PR TITLE
Catch error when trying to nack after an error

### DIFF
--- a/lib/set-consumer.js
+++ b/lib/set-consumer.js
@@ -195,5 +195,14 @@ function execAction(parsedMsg, rabQ, ch) {
       });
       const isRequeue = false;
       return ch.nack(parsedMsg.originMsg, false, isRequeue);
+    })
+    .catch(err => {
+      rabQ.emit('log', {
+        level: 'error',
+        uuid: parsedMsg.content.uuid,
+        token: parsedMsg.token,
+        msg: `Unable to nack message after error while treating message`,
+        err
+      });
     });
 }


### PR DESCRIPTION
Prevent unhandled promised error when it is not possible to nack message.
For example, when channel is closed, ch.nack will throw an error.