### PR TITLE
Add Checkqueue method in order to monitor queue via rab-q

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,6 +169,12 @@ class RabQ extends EventEmitter {
     return ch.checkExchange(this.exchange);
   }
 
+  checkQueue(name) {
+    const ch = _channel.get(this);
+
+    return ch.checkQueue(name);
+  }
+
   publish(routingKey, content, headers = {}, messageId = uuid.v4()) {
     const ch = _channel.get(this);
 

--- a/test/index.js
+++ b/test/index.js
@@ -178,6 +178,12 @@ test('healthcheck throws when error', async t => {
   await t.throws(p.healthcheck());
 });
 
+test('check queue retrieve informations', async t => {
+  const p = new RabQ(minimalOptions);
+  await p.start();
+  await t.notThrows(p.checkQueue('firstQueue'));
+});
+
 test('publish content', async t => {
   const p = new RabQ(minimalOptions);
   await p.start();


### PR DESCRIPTION
Adding a wrapping method for `checkQueue` channel's method in order to monitor a specific queue status.