### PR TITLE
Allow customizing the xQueryToken fallback

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
+          - 18
           - 15
           - 14
           - 12

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,7 @@ export interface RabQConfig {
   beforeHook?: (message: Message) => void;
   afterHook?: (message: Message, subscriberResult: Result) => void;
   prePublish?: (routingkey: string, content: Record<any, any>, properties?: Partial<MessageProperties>) => void;
+  xQueryTokenFallback?: () => string;
 }
 
 interface Logger {

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ class RabQ extends EventEmitter {
     this.beforeHook = opts.beforeHook || (() => {});
     this.afterHook = opts.afterHook || (() => {});
     this.prePublish = opts.prePublish || null;
+    this.xQueryTokenFallback = opts.xQueryTokenFallback || (() => uuid.v4());
 
     _connection.set(this, undefined);
     _channel.set(this, undefined);
@@ -202,7 +203,7 @@ class RabQ extends EventEmitter {
     }
 
     if (!properties.headers['x-query-token']) {
-      properties.headers['x-query-token'] = uuid.v4();
+      properties.headers['x-query-token'] = this.xQueryTokenFallback();
     }
 
     if (this.prePublish) {


### PR DESCRIPTION
This will allow customizing the behavior when the `xQueryToken` header is not provided, such as (for example) retrieving this value from an `asyncLocalStorage`

Also add the most recent LTS node version (18) in the tests