### PR TITLE
chore(deps): update uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "www.radiofrance.fr"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "eslint .",
@@ -34,7 +34,7 @@
     "@types/amqplib": "^0.10.1",
     "amqplib": "^0.10.3",
     "p-wait-for": "^1.0.0",
-    "uuid": "^3.0.1"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "ava": "^0.22.0",


### PR DESCRIPTION
### Changes

- Correctly states that it's compatible with node >=10 based on the requirements of the current dependencies
- Update `uuid` to get rid of a vulnerability warning